### PR TITLE
Handle missing OpenCV dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 streamlit
 pillow
 numpy
-opencv-python-headless
 paddleocr
 PyPDF2


### PR DESCRIPTION
## Summary
- make the OpenCV import optional and provide a numpy-based fallback for MRZ detection
- remove the OpenCV requirement so the Streamlit app works when cv2 wheels are unavailable

## Testing
- python -m compileall 'PP Scanning.py'

------
https://chatgpt.com/codex/tasks/task_e_68d811bbb9388333a206295cdd58a2bd