### PR TITLE
Pin PaddleOCR version to avoid PaddleX reinit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 streamlit
 pillow
 numpy
-paddleocr
+# Pin PaddleOCR to the pre-3.x series to avoid mandatory PaddleX initialization
+# that conflicts with Streamlit's rerun semantics.
+paddleocr==2.7.0.3
 PyPDF2


### PR DESCRIPTION
## Summary
- pin PaddleOCR to version 2.7.0.3 to avoid the new PaddleX auto-initialization logic that fails under Streamlit reruns
- document the reason for the pin directly in requirements.txt

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d81318e49c83338cef5811d80e6b4c