### PR TITLE
Handle PaddleX reinitialization errors

### DIFF
--- a/PP Scanning.py
+++ b/PP Scanning.py
@@ -31,7 +31,12 @@ def _patch_paddlex_repo_manager():  # pragma: no cover - optional dependency
     def initialize_once(*args, **kwargs):
         if getattr(repo_manager, "_INITIALIZED", False):
             return
-        result = original_initialize(*args, **kwargs)
+        try:
+            result = original_initialize(*args, **kwargs)
+        except RuntimeError as err:
+            if "PDX has already been initialized" not in str(err):
+                raise
+            result = None
         repo_manager._INITIALIZED = True  # type: ignore[attr-defined]
         return result
 


### PR DESCRIPTION
## Summary
- guard the patched PaddleX repo manager against repeated initialization failures
- allow PaddleOCR to be constructed even when PaddleX has already been initialized upstream

## Testing
- python -m compileall 'PP Scanning.py'


------
https://chatgpt.com/codex/tasks/task_e_68d814a1add88333abc3f5d78c5cd4d8