### PR TITLE
Add PyPDF2 dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ numpy
 # Pin PaddleOCR to the pre-3.x series to avoid mandatory PaddleX initialization
 # that conflicts with Streamlit's rerun semantics.
 paddleocr==2.7.0.3
+PyPDF2


### PR DESCRIPTION
## Summary
- add PyPDF2 to the app requirements so the manifest parser can import the library

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d819df35e483338d76b3caefbac1c5