### PR TITLE
Add EasyOCR fallback when RapidOCR package is unavailable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Passport MRZ Scanner – Local Setup Notes
 
 This Streamlit application reads passport Machine Readable Zone (MRZ) text using
-RapidOCR (ONNXRuntime) and matches it against a PDF crew/passenger manifest.  Only the
-packages listed in `requirements.txt` are required to run the app locally:
+RapidOCR (ONNXRuntime) and matches it against a PDF crew/passenger manifest.  If
+RapidOCR cannot be installed on your platform the app now falls back to
+[EasyOCR](https://github.com/JaidedAI/EasyOCR), so installing the packages
+listed in `requirements.txt` is sufficient to run the app locally:
 
 ```bash
 pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ streamlit
 pillow
 numpy
 rapidocr-onnxruntime
+easyocr
 PyPDF2


### PR DESCRIPTION
## Summary
- add an OCR wrapper that uses RapidOCR when available and falls back to EasyOCR
- document the new fallback in the README and add EasyOCR to the requirements list

## Testing
- python -m py_compile 'PP Scanning.py'

------
https://chatgpt.com/codex/tasks/task_e_68d82948365483338eadf1cca6f576ed